### PR TITLE
Fix patch in package files

### DIFF
--- a/src/crc32cer.app.src
+++ b/src/crc32cer.app.src
@@ -10,7 +10,6 @@
   , {links,[{"Github","https://github.com/kafka4beam/crc32cer.git"}]}
   , {build_tools,["rebar3"]}
   , {files,["c_src/*.h","c_src/*.c", "rebar.config",
-            "src", "Makefile", "CMakeLists.txt", "crc32cer_cmake.path"]}
+            "src", "Makefile", "CMakeLists.txt", "crc32c_cmake.patch"]}
   ]
 }.
-


### PR DESCRIPTION
There was a typo in the app.src file that was not including the CMake patch. The library compiles fine from itself, but if compiling from `kafka_protocol`, it will fail with Cmake 4.x, because the hex.pm package does not contain the patch.

Will need to release a new version and I can open another PR to `kafka_protocol` to use that version.

Failure with current version via hex.pm:

```console
[ 50%] Performing configure step for 'google-crc32c'
CMake Error at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
gmake[3]: *** [CMakeFiles/google-crc32c.dir/build.make:92: external/src/google-crc32c-stamp/google-crc32c-configure] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:122: CMakeFiles/google-crc32c.dir/all] Error 2
gmake[1]: *** [Makefile:136: all] Error 2
gmake[1]: Leaving directory '/Users/codeadict/Hack/kafka_protocol/_build/default/lib/crc32cer/c_build'
make: *** [nif] Error 2
===> Hook for compile failed!
```