### PR TITLE
fake we have port_specs so erlang.mk won't scan for c_src

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,8 @@
 
 {project_plugins, [rebar3_hex]}.
 
+{port_specs, []}.
+
 {pre_hooks, [{"(linux|darwin|solaris)", compile, "make nif"}]}.
 
 {eunit_opts, [{report,{eunit_surefire,[{dir,"."}]}}]}.


### PR DESCRIPTION
It does not seem to be compiling with Erlang.mk this fixes that. 