### PR TITLE
Build vendored crc32c with -fPIC to fix shared NIF linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ set_property(GLOBAL  PROPERTY CXX_STANDARD 11)
 set(CRC32C_BUILD_TESTS OFF)
 set(CRC32C_BUILD_BENCHMARKS OFF)
 set(CRC32C_USE_GLOG OFF)
+# The vendored google/crc32c is built as a static archive but linked into
+# the SHARED crc32cer_nif, so its objects must be position-independent.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(external/crc32c)
 
 # Set appropriate include and link directories


### PR DESCRIPTION
## Summary
- Set `CMAKE_POSITION_INDEPENDENT_CODE ON` before `add_subdirectory(external/crc32c)` so vendored `google/crc32c` targets (`crc32c`, `crc32c_arm64`, `crc32c_sse42`) are compiled with `-fPIC`.
- The NIF is built as `SHARED` but links the vendored library as a static archive; on toolchains that enforce PIC for shared objects (e.g. GCC 15 on openSUSE Tumbleweed) the current build fails with `relocation R_X86_64_32 ... recompile with -fPIC`.

Fixes #13.

## Test plan
- [x] `rebar3 compile` on GCC 15 (previously failed, should now link)
- [ ] `rebar3 compile` on older GCC / clang (should be unaffected)
- [ ] CI passes on existing matrix